### PR TITLE
returning is deprecated, please change to use .tap (rails 2.3.10 compatible)

### DIFF
--- a/lib/postmark_delivery_method.rb
+++ b/lib/postmark_delivery_method.rb
@@ -32,7 +32,7 @@ module PostmarkDeliveryMethod
   end
 
   def create_mail_with_postmark_extras
-    returning create_mail_without_postmark_extras do |mail|
+    create_mail_without_postmark_extras.tap do |mail|
       mail.tag = @tag                          if @tag
       mail.postmark_attachments = @attachments if @attachments
     end


### PR DESCRIPTION
I get a lot of these warnings when running my own specs under Rails 2.3.10:

DEPRECATION WARNING: Kernel#returning has been deprecated in favor of Object#tap. (called from create_mail at [...]/gems/postmark-rails-0.4.0/lib/postmark_delivery_method.rb:35)

This small commit fixes the deprecation issue.
