### PR TITLE
Fixed Deprecation Warning in Rails 2.3.10

### DIFF
--- a/lib/postmark_delivery_method.rb
+++ b/lib/postmark_delivery_method.rb
@@ -32,7 +32,7 @@ module PostmarkDeliveryMethod
   end
 
   def create_mail_with_postmark_extras
-    returning create_mail_without_postmark_extras do |mail|
+    create_mail_without_postmark_extras.tap do |mail|
       mail.tag = @tag                          if @tag
       mail.postmark_attachments = @attachments if @attachments
     end


### PR DESCRIPTION
Hey, I am updating an app to Rails 2.3.10 and noticed that there was a deprecation warning about Kernel#returning being replaced with Object#tap. It was filling my screen when running tests so I decided to fix it.

I noticed there weren't any tests for the Rails2 stuff so I didn't have any concrete way to know if what I did works 100%. I would be happy to add tests to make sure it still work ok, just let me know how you would prefer to split the tests based on Rails2 and Rails3. 
