### PR TITLE
Fix version number typo (0.10 -> 0.11)

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,6 +1,6 @@
 = Changelog
 
-== 0.10.0
+== 0.11.0
 
 * Updated the postmark gem dependency to 1.6.x.
 


### PR DESCRIPTION
The 0.11.0 release was mislabeled as 0.10.0.