### PR TITLE
Update suggested gem version to the latest one

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For Rails 2.3 please take a look at [version 0.4](https://github.com/wildbit/pos
 Add this to your Gemfile: (change version numbers if needed)
 
 ``` ruby
-gem 'postmark-rails', '~> 0.10.0'
+gem 'postmark-rails', '~> 0.12.0'
 ```
 
 Don’t forget to run `bundle install` command every time you change something in the Gemfile.


### PR DESCRIPTION
Version `0.10.0` requires an old version of gem `postmark`, which doesn't have the Stat API (https://github.com/wildbit/postmark-gem/wiki/The-Stats-API-support).

Using `gem 'postmark-rails', '~> 0.12.0'` solves the issue.