### PR TITLE
Add source code URL to gemspec

### DIFF
--- a/postmark-rails.gemspec
+++ b/postmark-rails.gemspec
@@ -10,6 +10,10 @@ Gem::Specification.new do |s|
   s.homepage = %q{http://postmarkapp.com}
   s.summary = %q{Postmark adapter for ActionMailer}
 
+  s.metadata = {
+    "source_code_uri" => "https://github.com/wildbit/postmark-rails"
+  }
+
   s.extra_rdoc_files = [
     "LICENSE",
      "README.md"


### PR DESCRIPTION
Will add link to source code from https://rubygems.org/gems/postmark-rails, and allow automated tools (like Dependabot) to find this repo when looking for changelogs.