### PR TITLE
Update minimum gem dependency to avoid use of deprecated TLS v1

### DIFF
--- a/postmark-rails.gemspec
+++ b/postmark-rails.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.rdoc_options = ["--charset=UTF-8"]
 
   s.add_dependency('actionmailer', ">= 3.0.0")
-  s.add_dependency('postmark', "~> 1.15")
+  s.add_dependency('postmark', ">= 1.21.3")
 
   s.add_development_dependency("rake")
 


### PR DESCRIPTION
https://postmarkapp.com/updates/upcoming-tls-configuration-changes-for-api-users-action-may-be-required

TLS v1.0 is deprecated.

The TLS1.0 default was removed in 
https://github.com/wildbit/postmark-gem/blob/master/CHANGELOG.rdoc#label-1.21.3
https://github.com/wildbit/postmark-gem/commit/529e9dba6d027c459a4761290eb1cdf62438f0af
so this seems like the right minimum.

If we don't want to make it work by default, we would at least need to set the min to 1.19.2 which enabled the configuration of TLS version
https://github.com/wildbit/postmark-gem/blob/master/CHANGELOG.rdoc#label-1.19.2

There's no obvious reason to hold back from updating the minimum from review of the changelog entries.